### PR TITLE
Change on half open logic in tryReset

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/circuit/CircuitBreaker.scala
+++ b/core/src/main/scala/io/chrisdavenport/circuit/CircuitBreaker.scala
@@ -507,8 +507,8 @@ object CircuitBreaker {
           }
           ref.modify {
             case closed: Closed => (closed, openOnFail(fa))
-            case open: Open =>
-              if (open.startedAt + open.resetTimeout.toMillis < now) (HalfOpen, onHalfOpen >> resetOnSuccess)
+            case Open(startedAt, resetTimeout) =>
+              if (startedAt == open.startedAt && open.resetTimeout == resetTimeout) (HalfOpen, onHalfOpen >> resetOnSuccess)
               else (open, onRejected >> F.raiseError[A](RejectedExecution(open)))
             case HalfOpen => (HalfOpen, onRejected >> F.raiseError[A](RejectedExecution(HalfOpen)))
           }.flatten

--- a/core/src/main/scala/io/chrisdavenport/circuit/CircuitBreaker.scala
+++ b/core/src/main/scala/io/chrisdavenport/circuit/CircuitBreaker.scala
@@ -507,9 +507,10 @@ object CircuitBreaker {
           }
           ref.modify {
             case closed: Closed => (closed, openOnFail(fa))
-            case Open(startedAt, resetTimeout) =>
-              if (startedAt == open.startedAt && open.resetTimeout == resetTimeout) (HalfOpen, onHalfOpen >> resetOnSuccess)
-              else (open, onRejected >> F.raiseError[A](RejectedExecution(open)))
+            case currentOpen: Open =>
+              if (currentOpen.startedAt == open.startedAt && currentOpen.resetTimeout == open.resetTimeout)
+                (HalfOpen, onHalfOpen >> resetOnSuccess)
+              else (currentOpen, onRejected >> F.raiseError[A](RejectedExecution(open)))
             case HalfOpen => (HalfOpen, onRejected >> F.raiseError[A](RejectedExecution(HalfOpen)))
           }.flatten
 

--- a/core/src/main/scala/io/chrisdavenport/circuit/CircuitBreaker.scala
+++ b/core/src/main/scala/io/chrisdavenport/circuit/CircuitBreaker.scala
@@ -510,7 +510,7 @@ object CircuitBreaker {
             case currentOpen: Open =>
               if (currentOpen.startedAt == open.startedAt && currentOpen.resetTimeout == open.resetTimeout)
                 (HalfOpen, onHalfOpen >> resetOnSuccess)
-              else (currentOpen, onRejected >> F.raiseError[A](RejectedExecution(open)))
+              else (currentOpen, onRejected >> F.raiseError[A](RejectedExecution(currentOpen)))
             case HalfOpen => (HalfOpen, onRejected >> F.raiseError[A](RejectedExecution(HalfOpen)))
           }.flatten
 

--- a/core/src/main/scala/io/chrisdavenport/circuit/CircuitBreaker.scala
+++ b/core/src/main/scala/io/chrisdavenport/circuit/CircuitBreaker.scala
@@ -495,7 +495,7 @@ object CircuitBreaker {
       )
     }
 
-    def tryReset[A](open:Open,fa: F[A]): F[A] = {
+    def tryReset[A](open:Open, fa: F[A]): F[A] = {
       clock.monotonic(TimeUnit.MILLISECONDS).flatMap { now =>
         if (open.startedAt + open.resetTimeout.toMillis >= now) onRejected >> F.raiseError(RejectedExecution(open))
         else {
@@ -507,8 +507,8 @@ object CircuitBreaker {
           }
           ref.modify {
             case closed: Closed => (closed, openOnFail(fa))
-            case open@Open(startedAt, resetTimeout) =>
-              if (startedAt == open.startedAt && open.resetTimeout == resetTimeout) (HalfOpen, onHalfOpen >> resetOnSuccess)
+            case open: Open =>
+              if (open.startedAt + open.resetTimeout.toMillis < now) (HalfOpen, onHalfOpen >> resetOnSuccess)
               else (open, onRejected >> F.raiseError[A](RejectedExecution(open)))
             case HalfOpen => (HalfOpen, onRejected >> F.raiseError[A](RejectedExecution(HalfOpen)))
           }.flatten


### PR DESCRIPTION
Not sure if the provided implementation is the original intention, but as far I can see, the current code is always `true` since it's checking the same `val`s

```scala
case open@Open(startedAt, resetTimeout) =>
  if (startedAt == open.startedAt && open.resetTimeout == resetTimeout)
```

Another option could be that I'm missing something 