### PR TITLE
Attempt to Make the Reset Action Uncancellable

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/circuit/CircuitBreaker.scala
+++ b/core/src/main/scala/io/chrisdavenport/circuit/CircuitBreaker.scala
@@ -27,7 +27,7 @@ package io.chrisdavenport.circuit
 
 import scala.concurrent.duration._
 
-import cats.effect.{Clock, Sync}
+import cats.effect.{Clock, Sync, ExitCase}
 import cats.effect.concurrent.{Ref}
 import cats.implicits._
 import cats.effect.implicits._
@@ -477,7 +477,7 @@ object CircuitBreaker {
             ref.modify {
               case Closed(failures) =>
                 val count = failures + 1
-                if (count >= maxFailures) (Open(now, resetTimeout), onOpen >> F.raiseError[A](err))
+                if (count >= maxFailures) (Open(now, resetTimeout), onOpen.attempt.void >> F.raiseError[A](err))
                 else (Closed(count), F.raiseError[A](err))
               case open: Open => (open, F.raiseError[A](err))
               case HalfOpen => (HalfOpen, F.raiseError[A](err))
@@ -496,7 +496,7 @@ object CircuitBreaker {
       )
     }
 
-    def tryReset[A](open:Open, fa: F[A]): F[A] = {
+    def tryReset[A](open: Open, fa: F[A]): F[A] = {
       clock.monotonic(TimeUnit.MILLISECONDS).flatMap { now =>
         if (open.startedAt + open.resetTimeout.toMillis >= now) onRejected >> F.raiseError(RejectedExecution(open))
         else {
@@ -507,17 +507,27 @@ object CircuitBreaker {
           def resetOnSuccess: F[A] = {
             fa.attempt.flatMap {
               case Left(err) => ref.set(backoff(open)) >> F.raiseError(err)
-              case Right(a) => onClosed >> ref.set(ClosedZero) as a
+              case Right(a) => onClosed.attempt.void >> ref.set(ClosedZero) as a
             }
           }
           ref.modify {
             case closed: Closed => (closed, openOnFail(fa))
             case currentOpen: Open =>
               if (currentOpen.startedAt == open.startedAt && currentOpen.resetTimeout == open.resetTimeout)
-                (HalfOpen, onHalfOpen >> resetOnSuccess)
-              else (currentOpen, onRejected >> F.raiseError[A](RejectedExecution(currentOpen)))
-            case HalfOpen => (HalfOpen, onRejected >> F.raiseError[A](RejectedExecution(HalfOpen)))
-          }.flatten.uncancelable
+                (HalfOpen, onHalfOpen.attempt.void >> resetOnSuccess)
+              else (currentOpen, onRejected.attempt.void >> F.raiseError[A](RejectedExecution(currentOpen)))
+            case HalfOpen => (HalfOpen, onRejected.attempt.void >> F.raiseError[A](RejectedExecution(HalfOpen)))
+          }.flatten.guaranteeCase{
+            // Handles the case of cancelation during this set of operations
+            // With autocancelable flatMap this guarantee might not hold.
+            case ExitCase.Canceled => ref.update{
+              case HalfOpen => open // We Don't leave this in a half-open state.
+              case closed: Closed => closed
+              case open: Open => open
+            }
+            case ExitCase.Error(_) => F.unit
+            case ExitCase.Completed => F.unit
+          }
 
         }
       }
@@ -527,7 +537,7 @@ object CircuitBreaker {
       ref.modify {
         case closed: Closed  => (closed, openOnFail(fa))
         case open: Open  => (open, tryReset(open, fa))
-        case HalfOpen => (HalfOpen,  onRejected >> F.raiseError[A](RejectedExecution(HalfOpen)))
+        case HalfOpen => (HalfOpen,  onRejected.attempt.void >> F.raiseError[A](RejectedExecution(HalfOpen)))
       }.flatten
     }
   }

--- a/core/src/test/scala/io/chrisdavenport/circuit/CircuitBreakerTests.scala
+++ b/core/src/test/scala/io/chrisdavenport/circuit/CircuitBreakerTests.scala
@@ -194,7 +194,7 @@ class CircuitBreakerTests extends AsyncFunSuite with Matchers {
         // Testing half-open state
         d <- Deferred[IO, Unit]
         fiber <- circuitBreaker.protect(d.get).start
-        _ <- IO.sleep(10.millis)
+        _ <- IO.sleep(1.second)
         _ = unsafeState() should matchPattern {
           case CircuitBreaker.HalfOpen =>
         }


### PR DESCRIPTION
I believe this was a possible problem with cancelation in 1.0 that hadn't been discovered. To prevent the issue that action that is a tryReset action that temporarily put the system in a HalfOpen state must in all conditions leave that state or we have a terminal state of the system that we do not want.