### PR TITLE
allow construction inside a separate effect from that of the circuit breaker

### DIFF
--- a/core/src/test/scala/io/chrisdavenport/circuit/CircuitBreakerTests.scala
+++ b/core/src/test/scala/io/chrisdavenport/circuit/CircuitBreakerTests.scala
@@ -26,6 +26,7 @@ package io.chrisdavenport.circuit
 
 import scala.concurrent.{ExecutionContext, Future}
 
+import cats.data.OptionT
 import cats.effect.{ContextShift, IO, Timer}
 import cats.effect.concurrent.{Deferred, Ref}
 import org.scalatest.Succeeded
@@ -47,10 +48,10 @@ class CircuitBreakerTests extends AsyncFunSuite with Matchers {
   implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
 
 
-  private def mkBreaker() = CircuitBreaker.of[IO](
+  private def mkBreaker() = CircuitBreaker.in[OptionT[IO, *], IO](
     maxFailures = 5,
     resetTimeout = 1.minute
-  ).unsafeRunSync()
+  ).value.unsafeRunSync().get
 
 
   test("should work for successful async IOs") {


### PR DESCRIPTION
CircuitBreaker as currently written doesn't support the pattern described by `Ref.in[F, G]`, in which the unsafe Ref is constructed safely inside effect F while exposing its own state via effect G. I propose implementing this pattern by generalizing the existing constructor to use `Ref.in` instead of `Ref.of`.