### PR TITLE
Update scala213V from 2.13.1 to 2.13.2.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
-val scala213V = "2.13.1"
+val scala213V = "2.13.2"
 val scala212V = "2.12.10"
 
 val catsV = "2.2.0"


### PR DESCRIPTION
Address error on compile:

```
sbt:circuit> projects
[info] In file:/Users/kevinmeredith/Workspace/circuit/
[info] 	 * circuit
[info] 	   core
[info] 	   docs
sbt:circuit> compile
...
8 warnings found
[info]   Compilation completed in 14.92s.
[error] 'nowarn' is not a valid choice for '-Wunused'
```

Credit goes to https://stackoverflow.com/a/62260673/409976.