### PR TITLE
windowing of errors

### DIFF
--- a/core/src/test/scala/io/chrisdavenport/circuit/CircuitBreakerTests.scala
+++ b/core/src/test/scala/io/chrisdavenport/circuit/CircuitBreakerTests.scala
@@ -354,14 +354,14 @@ class CircuitBreakerTests extends CatsEffectSuite {
 
   test("should only count errors in a Window if windowing is enabled") {
     for {
-      circuitBreaker <- CircuitBreaker.default[IO](maxFailures = 2, resetTimeout = 10.seconds).withFailureWindow(500.millis).build
+      circuitBreaker <- CircuitBreaker.default[IO](maxFailures = 2, resetTimeout = 10.seconds).withFailureWindow(1.second).build
       action = circuitBreaker.protect(IO.raiseError(new RuntimeException("Boom!"))).attempt
-      _ <- action >> IO.sleep(500.millis) >> action >> IO.sleep(500.millis) >> action
+      _ <- action >> IO.sleep(1.second) >> action >> IO.sleep(1.second) >> action
       _ <- circuitBreaker.state.map {
         case _: CircuitBreaker.Closed => assert(true)
         case _ => assert(false)
       }
-      _ <- IO.sleep(500.millis) >> action >> IO.sleep(50.millis) >> action
+      _ <- IO.sleep(1.second) >> action >> IO.sleep(50.millis) >> action
       _ <- circuitBreaker.state.map {
         case _: CircuitBreaker.Open => assert(true)
         case _ => assert(false)

--- a/core/src/test/scala/io/chrisdavenport/circuit/CircuitBreakerTests.scala
+++ b/core/src/test/scala/io/chrisdavenport/circuit/CircuitBreakerTests.scala
@@ -354,14 +354,14 @@ class CircuitBreakerTests extends CatsEffectSuite {
 
   test("should only count errors in a Window if windowing is enabled") {
     for {
-      circuitBreaker <- CircuitBreaker.default[IO](maxFailures = 2, resetTimeout = 10.seconds).withFailureWindow(200.millis).build
+      circuitBreaker <- CircuitBreaker.default[IO](maxFailures = 2, resetTimeout = 10.seconds).withFailureWindow(500.millis).build
       action = circuitBreaker.protect(IO.raiseError(new RuntimeException("Boom!"))).attempt
-      _ <- action >> IO.sleep(200.millis) >> action >> IO.sleep(200.millis) >> action
+      _ <- action >> IO.sleep(500.millis) >> action >> IO.sleep(500.millis) >> action
       _ <- circuitBreaker.state.map {
         case _: CircuitBreaker.Closed => assert(true)
         case _ => assert(false)
       }
-      _ <- IO.sleep(200.millis) >> action >> IO.sleep(50.millis) >> action
+      _ <- IO.sleep(500.millis) >> action >> IO.sleep(50.millis) >> action
       _ <- circuitBreaker.state.map {
         case _: CircuitBreaker.Open => assert(true)
         case _ => assert(false)

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,8 @@ can be in any of these 3 states:
 
 - When the `failures` counter reaches the `maxFailures` count,the breaker is tripped into `Open` state
 
+- If Windowing is enabled, i.e. windowSizeInMs > 0, then only `failures` within the window period are counted.
+
 **Open**: The circuit breaker rejects all tasks with an RejectedExecution
 
 - all tasks fail fast with `RejectedExecution`


### PR DESCRIPTION
Count errors over a window, e.g. 100 errors over a minute. Then trigger CB.
- Add simple window to error tracking before CB is Open
- Better docs
- Update site
